### PR TITLE
Add catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: constellate-notebooks
+  description: Auto-generated catalog-info.yaml.
+  tags:
+  - jupyter notebook
+  - javascript
+  - python
+spec:
+  type: unknown
+  owner: group:labs
+  lifecycle: unknown


### PR DESCRIPTION
This PR adds a `catalog-info.yaml` file to Backstage when merged. If your repo is GitHub Only, this will not be picked up Backstage presently.